### PR TITLE
fix error: invalid option "--with-http_spdy_module"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,6 @@ RUN cd /usr/src/nginx-$NGINX_VERSION \
         --with-compat \
         --with-file-aio \
         --with-http_v2_module \
-        --with-http_spdy_module \
         --with-http_v2_hpack_enc \
         --with-zlib=/usr/src/nginx-${NGINX_VERSION}/zlib \
         --add-module=/usr/src/nginx-${NGINX_VERSION}/ngx_brotli \


### PR DESCRIPTION
SPDY functions nginx-1.9.5+ now moved to http2 module.
https://github.com/denji/homebrew-nginx/issues/146